### PR TITLE
query-param-support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@ node_modules
 src
 .gitignore
 jest.config.js
+rollup.config.js
 notes
-tsconfig.json
+*.json
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -39,21 +39,43 @@ However, if a key is missing, an error is not thrown by default. If this behavio
 ```ts
 enum AppLink {
   ...
-  CUSTOMERID_SETTINGS_VIEW = "/[customerId]/settings/[view]",
+  CUSTOMERID_SETTINGS_VIEW = '/[customerId]/settings/[view]',
   ...
 }
 
 // throws an error
 fillLinkSafe(AppLink.CUSTOMERID_SETTINGS_VIEW, {
-    view: "templates"
-  }
-);
+  view: 'templates',
+});
 
-// does not throw an error, returns the first argument untouched
+// does not throw an error, returns null
 fillLink(AppLink.CUSTOMERID_SETTINGS_VIEW, {
-    view: "templates"
-  }
-);
+  view: 'templates',
+});
+```
+
+## Query Params
+
+Use the `$query` property to specify [query-parameters](https://en.wikipedia.org/wiki/Query_string)
+
+```ts
+enum AppLink {
+  ...
+  CATEGORYID_CONTENT_GENRE = '/[categoryId]/content/[genre]',
+  ...
+}
+
+// returns: '/music/content/jazz?artist=miles-davis&tune=so-what&year=1959&autoplay=true'
+fillLink(AppLink.CUSTOMERID_SETTINGS_VIEW, {
+  categoryId: 'music',
+  genre: 'jazz',
+  $query: {
+    artist: 'miles-davis',
+    tune: 'so-what',
+    year: 1959,
+    autoplay: true,
+  },
+});
 ```
 
 ---
@@ -64,36 +86,36 @@ There's a bit of type-safety as well. If an unknown key is specified in the repl
 
 ```ts
 // OK
-fillLink("/hello/[there]", { there: "something" });
+fillLink('/hello/[there]', { there: 'something' });
 
 // Error on `hello` key:
 // Type 'string' is not assignable to type 'never'
-fillLink("/hello/[there]", { there: "something", hello: "something-else " });
+fillLink('/hello/[there]', { there: 'something', hello: 'something-else ' });
 ```
 
 Also on catch-all routes, the type expected is always an array of strings. For optional-catch-all routes, `[[...slug]]` an empty array is accepted, as optional catch all routes includes the index of the path, while catch all routes, `[...slug]` only accepts a non-empty array.
 
 ```ts
 // OK
-fillLink("/hello/[...there]", { there: ["something"] });
+fillLink('/hello/[...there]', { there: ['something'] });
 
 // Error on `there` key:
 // Type 'string' is not assignable to type '[string, ...string[]]'
-fillLink("/hello/[...there]", { there: "something" });
+fillLink('/hello/[...there]', { there: 'something' });
 
 // Error on `there` key:
 // Source has 0 element(s) but target requires 1
-fillLink("/hello/[...there]", { there: [] });
+fillLink('/hello/[...there]', { there: [] });
 
 // OK
-fillLink("/hello/[[...there]]", { there: [] });
+fillLink('/hello/[[...there]]', { there: [] });
 
 // OK
-fillLink("/hello/[[...there]]", { there: ["something"] });
+fillLink('/hello/[[...there]]', { there: ['something'] });
 
 // Error on `there` key:
 // Type 'string' is not assignable to type 'string[]'
-fillLink("/hello/[[...there]]", { there: "something" });
+fillLink('/hello/[[...there]]', { there: 'something' });
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,33 +14,27 @@ This program is intended to be used with [generate-next-links](https://github.co
 
 ```ts
 enum AppLink {
-  ...
-  CUSTOMERID_SETTINGS_VIEW = "/[customerId]/settings/[view]",
-  BLOG_OPTIONAL_CATCHALL_SLUG = "/blog/[[...slug]]",
-  ...
+  CUSTOMERID_SETTINGS_VIEW = '/[customerId]/settings/[view]',
+  BLOG_OPTIONAL_CATCHALL_SLUG = '/blog/[[...slug]]',
 }
 
 // returns: '/some-id/settings/templates'
 fillLink(AppLink.CUSTOMERID_SETTINGS_VIEW, {
-    customerId: "some-id",
-    view: "templates"
-  }
-)
+  customerId: 'some-id',
+  view: 'templates',
+});
 
 // returns: '/blog/category/music/jazz/miles-davis'
 fillLink(AppLink.BLOG_OPTIONAL_CATCHALL_SLUG, {
-    slug: ["category", "music", "jazz", "miles-davis"]
-  }
-);
+  slug: ['category', 'music', 'jazz', 'miles-davis'],
+});
 ```
 
 However, if a key is missing, an error is not thrown by default. If this behavior is desired, use `fillLinkSafe`.
 
 ```ts
 enum AppLink {
-  ...
   CUSTOMERID_SETTINGS_VIEW = '/[customerId]/settings/[view]',
-  ...
 }
 
 // throws an error
@@ -56,17 +50,15 @@ fillLink(AppLink.CUSTOMERID_SETTINGS_VIEW, {
 
 ## Query Params
 
-Use the `$query` property to specify [query-parameters](https://en.wikipedia.org/wiki/Query_string)
+Use the `$query` property to specify an object containing [query-parameters](https://en.wikipedia.org/wiki/Query_string). Note that properties of the `$query` object must have values of a `primitive` type.
 
 ```ts
 enum AppLink {
-  ...
   CATEGORYID_CONTENT_GENRE = '/[categoryId]/content/[genre]',
-  ...
 }
 
 // returns: '/music/content/jazz?artist=miles-davis&tune=so-what&year=1959&autoplay=true'
-fillLink(AppLink.CUSTOMERID_SETTINGS_VIEW, {
+fillLink(AppLink.CATEGORYID_CONTENT_GENRE, {
   categoryId: 'music',
   genre: 'jazz',
   $query: {

--- a/__tests__/catchall.test.ts
+++ b/__tests__/catchall.test.ts
@@ -1,24 +1,24 @@
-import { fillLink, fillLinkSafe } from "../src/index";
+import { fillLink, fillLinkSafe } from '../src/index';
 
-describe("Catchall Test Suite", () => {
+describe('Catchall Test Suite', () => {
   test.each([
-    ["safe", fillLinkSafe],
-    ["unsafe", fillLink],
-  ])("%s: can fill single catchall slug", (_, fn) => {
+    ['safe', fillLinkSafe],
+    ['unsafe', fillLink],
+  ])('%s: can fill single catchall slug', (_, fn) => {
     expect(
-      fn("/posts/[...slug]", {
-        slug: ["category"],
+      fn('/posts/[...slug]', {
+        slug: ['category'],
       })
-    ).toEqual("/posts/category");
+    ).toEqual('/posts/category');
   });
   test.each([
-    ["safe", fillLinkSafe],
-    ["unsafe", fillLink],
-  ])("%s: can fill multiple catchall slugs", (_, fn) => {
+    ['safe', fillLinkSafe],
+    ['unsafe', fillLink],
+  ])('%s: can fill multiple catchall slugs', (_, fn) => {
     expect(
-      fn("/posts/[...slug]", {
-        slug: ["category", "music", "jazz", "miles-davis"],
+      fn('/posts/[...slug]', {
+        slug: ['category', 'music', 'jazz', 'miles-davis'],
       })
-    ).toEqual("/posts/category/music/jazz/miles-davis");
+    ).toEqual('/posts/category/music/jazz/miles-davis');
   });
 });

--- a/__tests__/optional-catchall.test.ts
+++ b/__tests__/optional-catchall.test.ts
@@ -1,51 +1,51 @@
-import { fillLink, fillLinkSafe } from "../src/index";
+import { fillLink, fillLinkSafe } from '../src/index';
 
 type T = [string, string[], string];
 
-const optRootArgs: T = ["/[[...slug]]", ["category"], "/category"];
-const optRootEmptyArgs: T = ["/[[...slug]]", [""], "/"];
+const optRootArgs: T = ['/[[...slug]]', ['category'], '/category'];
+const optRootEmptyArgs: T = ['/[[...slug]]', [''], '/'];
 const optNestedArgs: T = [
-  "/user/[[...slug]]",
-  ["settings", "visual", "themes"],
-  "/user/settings/visual/themes",
+  '/user/[[...slug]]',
+  ['settings', 'visual', 'themes'],
+  '/user/settings/visual/themes',
 ];
 
-describe("Optional Catchall Test Suite", () => {
+describe('Optional Catchall Test Suite', () => {
   test.each([
-    ["safe", "root", fillLinkSafe, ...optRootArgs],
-    ["unsafe", "root", fillLink, ...optRootArgs],
-    ["safe", "root", fillLinkSafe, ...optRootEmptyArgs],
-    ["unsafe", "root", fillLink, ...optRootEmptyArgs],
-    ["safe", "nested", fillLinkSafe, ...optNestedArgs],
-    ["unsafe", "nested", fillLink, ...optNestedArgs],
+    ['safe', 'root', fillLinkSafe, ...optRootArgs],
+    ['unsafe', 'root', fillLink, ...optRootArgs],
+    ['safe', 'root', fillLinkSafe, ...optRootEmptyArgs],
+    ['unsafe', 'root', fillLink, ...optRootEmptyArgs],
+    ['safe', 'nested', fillLinkSafe, ...optNestedArgs],
+    ['unsafe', 'nested', fillLink, ...optNestedArgs],
   ])(
-    "%s - %s: can fill single optional catchall slug",
+    '%s - %s: can fill single optional catchall slug',
     (_, __, fn, link, args, expected) => {
       expect(
-        fn<string, {}>(link, {
+        fn<any, any>(link, {
           slug: args,
         })
       ).toEqual(expected);
     }
   );
   test.each([
-    ["safe", fillLinkSafe],
-    ["unsafe", fillLink],
-  ])("%s: can fill multiple optional catchall slugs", (_, fn) => {
+    ['safe', fillLinkSafe],
+    ['unsafe', fillLink],
+  ])('%s: can fill multiple optional catchall slugs', (_, fn) => {
     expect(
-      fn("/[[...slug]]", {
-        slug: ["category", "music", "jazz", "miles-davis"],
+      fn('/[[...slug]]', {
+        slug: ['category', 'music', 'jazz', 'miles-davis'],
       })
-    ).toEqual("/category/music/jazz/miles-davis");
+    ).toEqual('/category/music/jazz/miles-davis');
   });
   test.each([
-    ["safe", fillLinkSafe],
-    ["unsafe", fillLink],
-  ])("%s: empty optional catchall slug array is accepted", (_, fn) => {
+    ['safe', fillLinkSafe],
+    ['unsafe', fillLink],
+  ])('%s: empty optional catchall slug array is accepted', (_, fn) => {
     expect(
-      fn("/[[...slug]]", {
+      fn<any, any>('/[[...slug]]', {
         slug: [],
       })
-    ).toEqual("/");
+    ).toEqual('/');
   });
 });

--- a/__tests__/query.test.ts
+++ b/__tests__/query.test.ts
@@ -1,0 +1,6 @@
+import { fillLink, fillLinkSafe } from "../src/index";
+
+describe("Query Test Suite", () => {
+  test("", () => {
+  });
+});

--- a/__tests__/query.test.ts
+++ b/__tests__/query.test.ts
@@ -9,7 +9,7 @@ describe('Query Test Suite', () => {
           music: 'jazz',
           artist: 'miles-davis',
           tune: 'so-what',
-          year: 1967,
+          year: 1959,
           autoplay: true,
         },
       })
@@ -25,7 +25,7 @@ describe('Query Test Suite', () => {
           music: 'jazz',
           artist: 'miles-davis',
           tune: 'so-what',
-          year: 1967,
+          year: 1959,
           autoplay: false,
         },
       })

--- a/__tests__/query.test.ts
+++ b/__tests__/query.test.ts
@@ -10,10 +10,27 @@ describe('Query Test Suite', () => {
           artist: 'miles-davis',
           tune: 'so-what',
           year: 1967,
+          autoplay: true,
         },
       })
     ).toEqual(
-      '/admin/user/1?music=jazz&artist=miles-davis&tune=so-what&year=1967'
+      '/admin/user/1?music=jazz&artist=miles-davis&tune=so-what&year=1959&autoplay=true'
+    );
+  });
+  test('unsafe: can fill single key with $query', () => {
+    expect(
+      fillLink('/admin/user/[id]', {
+        id: 1,
+        $query: {
+          music: 'jazz',
+          artist: 'miles-davis',
+          tune: 'so-what',
+          year: 1967,
+          autoplay: false,
+        },
+      })
+    ).toEqual(
+      '/admin/user/1?music=jazz&artist=miles-davis&tune=so-what&year=1959&autoplay=false'
     );
   });
 });

--- a/__tests__/query.test.ts
+++ b/__tests__/query.test.ts
@@ -1,6 +1,19 @@
-import { fillLink, fillLinkSafe } from "../src/index";
+import { fillLink, fillLinkSafe } from '../src/index';
 
-describe("Query Test Suite", () => {
-  test("", () => {
+describe('Query Test Suite', () => {
+  test('safe: can fill single key with $query', () => {
+    expect(
+      fillLinkSafe('/admin/user/[id]', {
+        id: 1,
+        $query: {
+          music: 'jazz',
+          artist: 'miles-davis',
+          tune: 'so-what',
+          year: 1967,
+        },
+      })
+    ).toEqual(
+      '/admin/user/1?music=jazz&artist=miles-davis&tune=so-what&year=1967'
+    );
   });
 });

--- a/__tests__/standard.test.ts
+++ b/__tests__/standard.test.ts
@@ -48,6 +48,6 @@ describe('Standard Test Suite', () => {
     ).toEqual(null);
   });
   test('all: defined but empty value is accepted', () => {
-    expect(fillLink('/admin/user/[id]', { id: 1 })).toEqual('/admin/user/');
+    expect(fillLink('/admin/user/[id]', { id: '' })).toEqual('/admin/user/');
   });
 });

--- a/__tests__/standard.test.ts
+++ b/__tests__/standard.test.ts
@@ -1,53 +1,53 @@
-import { fillLink, fillLinkSafe } from "../src/index";
+import { fillLink, fillLinkSafe } from '../src/index';
 
-describe("Standard Test Suite", () => {
-  test("safe: can fill single key", () => {
-    expect(fillLinkSafe("/admin/user/[id]", { id: "1" })).toEqual(
-      "/admin/user/1"
+describe('Standard Test Suite', () => {
+  test('safe: can fill single key', () => {
+    expect(fillLinkSafe('/admin/user/[id]', { id: '1' })).toEqual(
+      '/admin/user/1'
     );
   });
-  test("safe: can fill nested keys", () => {
+  test('safe: can fill nested keys', () => {
     expect(
-      fillLinkSafe("/admin/user/[id]/dashboard/[view]", {
-        id: "1",
-        view: "analytics",
+      fillLinkSafe('/admin/user/[id]/dashboard/[view]', {
+        id: '1',
+        view: 'analytics',
       })
-    ).toEqual("/admin/user/1/dashboard/analytics");
+    ).toEqual('/admin/user/1/dashboard/analytics');
   });
-  test("safe: throws error on missing nested keys", () => {
+  test('safe: throws error on missing nested keys', () => {
     expect(() =>
-      fillLinkSafe("/admin/user/[id]/dashboard/[view]", {
-        view: "analytics",
+      fillLinkSafe('/admin/user/[id]/dashboard/[view]', {
+        view: 'analytics',
       })
     ).toThrow(
       "Error: key 'id' is missing from replacer object in link '/admin/user/[id]/dashboard/[view]'"
     );
   });
-  test("safe: throws error on missing single key", () => {
-    expect(() => fillLinkSafe("/admin/user/[id]", {})).toThrow(
+  test('safe: throws error on missing single key', () => {
+    expect(() => fillLinkSafe('/admin/user/[id]', {})).toThrow(
       "Error: key 'id' is missing from replacer object in link '/admin/user/[id]'"
     );
   });
-  test("unsafe: can fill single key", () => {
-    expect(fillLink("/admin/user/[id]", { id: "1" })).toEqual("/admin/user/1");
+  test('unsafe: can fill single key', () => {
+    expect(fillLink('/admin/user/[id]', { id: 1 })).toEqual('/admin/user/1');
   });
-  test("unsafe: can fill nested keys", () => {
+  test('unsafe: can fill nested keys', () => {
     expect(
-      fillLink("/admin/user/[id]/dashboard/[view]", {
-        id: "1",
-        view: "analytics",
+      fillLink('/admin/user/[id]/dashboard/[view]', {
+        id: 1,
+        view: 'analytics',
       })
-    ).toEqual("/admin/user/1/dashboard/analytics");
+    ).toEqual('/admin/user/1/dashboard/analytics');
   });
-  test("unsafe: does not throw error on missing single key", () => {
-    expect(fillLink("/admin/user/[id]", {})).toEqual(null);
+  test('unsafe: does not throw error on missing single key', () => {
+    expect(fillLink('/admin/user/[id]', {})).toEqual(null);
   });
-  test("unsafe: does not throw error on missing nested keys", () => {
+  test('unsafe: does not throw error on missing nested keys', () => {
     expect(
-      fillLink("/admin/user/[id]/dashboard/[view]", { view: "analytics" })
+      fillLink('/admin/user/[id]/dashboard/[view]', { view: 'analytics' })
     ).toEqual(null);
   });
-  test("all: defined but empty value is accepted", () => {
-    expect(fillLink("/admin/user/[id]", { id: "" })).toEqual("/admin/user/");
+  test('all: defined but empty value is accepted', () => {
+    expect(fillLink('/admin/user/[id]', { id: 1 })).toEqual('/admin/user/');
   });
 });

--- a/__tests__/standard.test.ts
+++ b/__tests__/standard.test.ts
@@ -40,12 +40,12 @@ describe("Standard Test Suite", () => {
     ).toEqual("/admin/user/1/dashboard/analytics");
   });
   test("unsafe: does not throw error on missing single key", () => {
-    expect(fillLink("/admin/user/[id]", {})).toEqual("/admin/user/[id]");
+    expect(fillLink("/admin/user/[id]", {})).toEqual(null);
   });
   test("unsafe: does not throw error on missing nested keys", () => {
     expect(
       fillLink("/admin/user/[id]/dashboard/[view]", { view: "analytics" })
-    ).toEqual("/admin/user/[id]/dashboard/[view]");
+    ).toEqual(null);
   });
   test("all: defined but empty value is accepted", () => {
     expect(fillLink("/admin/user/[id]", { id: "" })).toEqual("/admin/user/");

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   roots: ["<rootDir>"],
   testMatch: ["**/__tests__/**/*.test.+(ts|tsx|js)"],
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig-test.json',
+    },
+  },
   transform: {
     "^.+\\.(ts|tsx)$": "ts-jest",
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cl-fill-link",
   "license": "MIT",
   "description": "Fill generated nextjs links with dynamic values ",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "author": {
     "name": "Christian Lindeneg",
     "email": "hi@lindeneg.org",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://lindeneg.org"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rollup -c",
     "test": "jest --verbose"
   },
   "keywords": [
@@ -25,13 +25,22 @@
     "url": "git+https://github.com/lindeneg/cl-fill-link.git"
   },
   "homepage": "https://github.com/lindeneg/cl-fill-link#readme",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/bundle.cjs.js",
+  "module": "./dist/bundle.esm.js",
+  "types": "./dist/index.d.ts",
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^21.0.2",
+    "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.13",
     "jest": "^27.4.5",
+    "rollup": "^2.70.1",
+    "rollup-plugin-cleaner": "^1.0.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-typescript2": "^0.31.2",
     "ts-jest": "^27.1.1",
     "typescript": "^4.5.4"
-  }
+  },
+  "dependencies": {}
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-undef */
+import typescript from 'rollup-plugin-typescript2';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import cleaner from 'rollup-plugin-cleaner';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: './src/index.ts',
+  output: [
+    {
+      file: './dist/bundle.cjs.js',
+      format: 'cjs',
+    },
+    {
+      file: './dist/bundle.esm.js',
+      format: 'esm',
+    },
+  ],
+  plugins: [
+    cleaner({
+      targets: ['./dist'],
+    }),
+    peerDepsExternal(),
+    resolve(),
+    commonjs(),
+    typescript({
+      tsconfig: './tsconfig-build.json',
+    }),
+    terser(),
+  ],
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,6 @@ export function fillLink<T extends string, K extends ObjConstraint>(
     if (process.env.NODE_ENV === 'development') {
       console.log(err);
     }
-    return null;
   }
+  return null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,13 +75,13 @@ export function fillLinkSafe<T extends string, K extends Obj>(
 export function fillLink<T extends string, K extends Obj>(
   link: T,
   replacer: Replacer<T, K>
-) {
+): string | null {
   try {
     return fillLinkSafe(link, replacer);
   } catch (err) {
-    if (process.env.NODE_ENV === "development") {
+    if (process.env.NODE_ENV === 'development') {
       console.log(err);
     }
-    return link;
+    return null;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ function appendQuery<T extends Query>(l: string, query?: T): string {
   let q = '';
   if (query && keys.length > 0) {
     q += '?';
-    const keys = Object.keys(query);
     const length = keys.length - 1;
     keys.forEach((key, idx) => {
       const val = getString(query[<keyof T>key]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,25 +44,32 @@ function appendQuery<T extends Query>(l: string, query?: T): string {
 export function fillLinkSafe<T extends string, K extends Obj>(
   link: T,
   replacer: Replacer<T, K>
-) {
-  return link
-    .split("/")
-    .map((e) => {
-      const matches = /\[{1,2}\.{0,3}(\w+)\]{1,2}/.exec(e);
-      if (matches && matches.length > 1) {
-        const key = matches[1];
-        const val = replacer[key];
-        if (typeof val !== "undefined") {
-          return Array.isArray(val) ? val.join("/") : val;
-        } else {
-          throw new Error(
-            `Error: key '${key}' is missing from replacer object in link '${link}'`
-          );
+): string {
+  return appendQuery(
+    link
+      .split('/')
+      .map((e) => {
+        const matches = /\[{1,2}\.{0,3}(\w+)\]{1,2}/.exec(e);
+        if (matches && matches.length > 1) {
+          const key = matches[1];
+          const val = getString(replacer[key]);
+          if (typeof val !== 'undefined') {
+            return Array.isArray(val) ? val.join('/') : val;
+          } else {
+            throw new Error(
+              "Error: key '" +
+                key +
+                "' is missing from replacer object in link '" +
+                link +
+                "'"
+            );
+          }
         }
-      }
-      return e;
-    })
-    .join("/");
+        return e;
+      })
+      .join('/'),
+    replacer?.$query || {}
+  );
 }
 
 export function fillLink<T extends string, K extends Obj>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
-type Obj = Record<string, unknown>;
+type PrimitiveTypeConstraint = boolean | string | number | Date;
+
+type Obj = Record<string, PrimitiveTypeConstraint>;
+type Query = { $query?: PrimitiveTypeConstraint };
 
 type ReplacerValue<T extends string, K extends unknown> = K extends string
   ? T extends `${infer U}[...${K}]`
-    ? [string, ...string[]]
+    ? [PrimitiveTypeConstraint, ...PrimitiveTypeConstraint[]]
     : T extends `${infer P}[[...${K}]]`
-    ? string[]
+    ? PrimitiveTypeConstraint[]
     : T extends `${infer M}[${K}]${infer N}`
-    ? string
+    ? PrimitiveTypeConstraint
     : never
   : never;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,9 @@ function getString(target: unknown): string {
 }
 
 function appendQuery<T extends Query>(l: string, query?: T): string {
+  const keys = Object.keys(query || []);
   let q = '';
-  if (query) {
+  if (query && keys.length > 0) {
     q += '?';
     const keys = Object.keys(query);
     const length = keys.length - 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
-type PrimitiveTypeConstraint = boolean | string | number | Date;
-
-type Obj = Record<string, PrimitiveTypeConstraint>;
-type Query = { $query?: Obj };
+type PrimitiveTypeConstraint = boolean | string | number;
+type Obj<T> = Record<string, T>;
+type QueryConstraint = Obj<PrimitiveTypeConstraint>;
+type ObjConstraint = Obj<unknown>;
+type Query = { $query?: QueryConstraint };
 
 type ReplacerValue<T extends string, K extends unknown> = K extends string
-  ? T extends `${infer U}[...${K}]`
+  ? K extends '$query'
+    ? QueryConstraint
+    : T extends `${infer U}[...${K}]`
     ? [PrimitiveTypeConstraint, ...PrimitiveTypeConstraint[]]
     : T extends `${infer P}[[...${K}]]`
     ? PrimitiveTypeConstraint[]
@@ -13,7 +16,7 @@ type ReplacerValue<T extends string, K extends unknown> = K extends string
     : never
   : never;
 
-type Replacer<T extends string, U extends Obj> = {
+type Replacer<T extends string, U extends ObjConstraint> = {
   [K in keyof U]: ReplacerValue<T, K>;
 } & Query;
 
@@ -42,7 +45,7 @@ function appendQuery<T extends Query>(l: string, query?: T): string {
   return l + q;
 }
 
-export function fillLinkSafe<T extends string, K extends Obj>(
+export function fillLinkSafe<T extends string, K extends ObjConstraint>(
   link: T,
   replacer: Replacer<T, K>
 ): string {
@@ -73,7 +76,7 @@ export function fillLinkSafe<T extends string, K extends Obj>(
   );
 }
 
-export function fillLink<T extends string, K extends Obj>(
+export function fillLink<T extends string, K extends ObjConstraint>(
   link: T,
   replacer: Replacer<T, K>
 ): string | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export function fillLinkSafe<T extends string, K extends Obj>(
         return e;
       })
       .join('/'),
-    replacer?.$query || {}
+    replacer?.$query
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,31 @@ type ReplacerValue<T extends string, K extends unknown> = K extends string
 
 type Replacer<T extends string, U extends Obj> = {
   [K in keyof U]: ReplacerValue<T, K>;
-};
+} & Query;
+
+function getString(target: unknown): string {
+  try {
+    return String(target);
+  } catch (_) {
+    return '';
+  }
+}
+
+function appendQuery<T extends Query>(l: string, query?: T): string {
+  let q = '?';
+  if (query) {
+    const keys = Object.keys(query);
+    const length = keys.length - 1;
+    keys.forEach((key, idx) => {
+      const val = getString(query[<keyof T>key]);
+      q += key + '=' + val;
+      if (idx < length) {
+        q += '&';
+      }
+    });
+  }
+  return l + q;
+}
 
 export function fillLinkSafe<T extends string, K extends Obj>(
   link: T,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 type PrimitiveTypeConstraint = boolean | string | number | Date;
 
 type Obj = Record<string, PrimitiveTypeConstraint>;
-type Query = { $query?: PrimitiveTypeConstraint };
+type Query = { $query?: Obj };
 
 type ReplacerValue<T extends string, K extends unknown> = K extends string
   ? T extends `${infer U}[...${K}]`

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,9 +54,9 @@ export function fillLinkSafe<T extends string, K extends Obj>(
         const matches = /\[{1,2}\.{0,3}(\w+)\]{1,2}/.exec(e);
         if (matches && matches.length > 1) {
           const key = matches[1];
-          const val = getString(replacer[key]);
+          const val = replacer[key];
           if (typeof val !== 'undefined') {
-            return Array.isArray(val) ? val.join('/') : val;
+            return Array.isArray(val) ? val.join('/') : getString(val);
           } else {
             throw new Error(
               "Error: key '" +

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,9 @@ function getString(target: unknown): string {
 }
 
 function appendQuery<T extends Query>(l: string, query?: T): string {
-  let q = '?';
+  let q = '';
   if (query) {
+    q += '?';
     const keys = Object.keys(query);
     const length = keys.length - 1;
     keys.forEach((key, idx) => {

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,101 +1,12 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Enable incremental compilation */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
-    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-
-    /* Modules */
-    "module": "es2015",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files */
-    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
-
-    /* Emit */
-    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
-    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
-    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "target": "ESNext",
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
   }
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -24,7 +24,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "es2015",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -97,6 +97,5 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  },
-  "include": ["src"]
+  }
 }

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig-base.json",
+  "include": ["src"],
+  "exclude": ["__tests__"]
+}

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig-base.json",
+  "include": ["src", "__tests__"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.10.4":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
@@ -129,6 +136,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
@@ -149,6 +161,15 @@
   integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.16.7":
+  version "7.16.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
+  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -471,6 +492,48 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@rollup/plugin-commonjs@^21.0.2":
+  version "21.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.2.tgz#0b9c539aa1837c94abfaf87945838b0fc8564891"
+  integrity sha512-d/OmjaLVO4j/aQX69bwpWPpbvI3TJkQuxoAk7BH8ew1PyoMBLTOuvJTjzG8oEoW7drIIqB0KCJtfFLu/2GClWg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-node-resolve@^13.1.3":
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz#2ed277fb3ad98745424c1d2ba152484508a92d79"
+  integrity sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
+"@rollup/pluginutils@^4.1.2":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.0.tgz#a14bbd058fdbba0a5647143b16ed0d86fb60bd08"
+  integrity sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -523,6 +586,16 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/estree@*":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -567,6 +640,13 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
@@ -583,6 +663,15 @@
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@yarn-tool/resolve-package@^1.0.40":
+  version "1.0.46"
+  resolved "https://registry.yarnpkg.com/@yarn-tool/resolve-package/-/resolve-package-1.0.46.tgz#db7354380e5ca7682294af59e5ab0f7fce640ac1"
+  integrity sha512-RJcBGTVywUqYGRtGkPSgJC/ozf0wK/xjUy66tXkbpL35U0o1oef4S0v23euxA/CiukqBWr2fRGtGY6FidESdTg==
+  dependencies:
+    pkg-dir "< 6 >= 5"
+    tslib "^2.3.1"
+    upath2 "^3.1.12"
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
@@ -611,6 +700,11 @@ acorn@^8.2.4:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
   integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+
+acorn@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 agent-base@6:
   version "6.0.2"
@@ -786,6 +880,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -887,6 +986,16 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1036,6 +1145,16 @@ estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -1097,12 +1216,29 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-cache-dir@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
     locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
     path-exists "^4.0.0"
 
 form-data@^3.0.0:
@@ -1114,12 +1250,21 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+fs-extra@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.1.tgz#27de43b4320e833f6867cc044bfce29fdf0ef3b8"
+  integrity sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -1149,7 +1294,7 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -1165,6 +1310,11 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 graceful-fs@^4.2.4:
   version "4.2.8"
@@ -1262,6 +1412,13 @@ is-core-module@^2.2.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  dependencies:
+    has "^1.0.3"
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -1272,6 +1429,11 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -1281,6 +1443,13 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -1742,6 +1911,15 @@ jest-watcher@^27.4.2:
     jest-util "^27.4.2"
     string-length "^4.0.1"
 
+jest-worker@^26.2.1:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 jest-worker@^27.4.5:
   version "27.4.5"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.5.tgz#d696e3e46ae0f24cff3fa7195ffba22889262242"
@@ -1818,6 +1996,15 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -1843,6 +2030,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -1860,7 +2054,14 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^3.0.0:
+magic-string@^0.25.7:
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -1991,12 +2192,26 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2018,15 +2233,29 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-is-network-drive@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/path-is-network-drive/-/path-is-network-drive-1.0.13.tgz#c9aa0183eb72c328aa83f43def93ddcb9d7ec4d4"
+  integrity sha512-Hg74mRN6mmXV+gTm3INjFK40ncAmC/Lo4qoQaSZ+GT3hZzlKdWQSqAjqyPeW0SvObP2W073WyYEBWY9d3wOm3A==
+  dependencies:
+    tslib "^2.3.1"
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-strip-sep@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/path-strip-sep/-/path-strip-sep-1.0.10.tgz#2be4e789406b298af8709ff79af716134b733b98"
+  integrity sha512-JpCy+8LAJQQTO1bQsb/84s1g+/Stm3h39aOpPRBQ/paMUGVPPZChLTOTKHoaCkc/6sKuF7yVsnq5Pe1S6xQGcA==
+  dependencies:
+    tslib "^2.3.1"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -2038,12 +2267,24 @@ picomatch@^2.0.4, picomatch@^2.2.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
+picomatch@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 pirates@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.4.tgz#07df81e61028e402735cdd49db701e4885b4e6e6"
   integrity sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==
 
-pkg-dir@^4.2.0:
+"pkg-dir@< 6 >= 5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
+
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -2083,6 +2324,13 @@ punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -2110,6 +2358,15 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
+resolve@^1.17.0, resolve@^1.19.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
+  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+  dependencies:
+    is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
@@ -2118,12 +2375,65 @@ resolve@^1.20.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-cleaner@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-cleaner/-/rollup-plugin-cleaner-1.0.0.tgz#9f2d7226327fca9109b68c18fea77b427e33c193"
+  integrity sha512-q+Zf9estkFwGede9QzmbkhKeuXzlliOvcICVNzBHAs5xYPPs1XLtfin5TMU2tC2EYjmfaF97saY9MnQM6Og4eA==
+  dependencies:
+    rimraf "^2.6.3"
+
+rollup-plugin-peer-deps-external@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz#8a420bbfd6dccc30aeb68c9bf57011f2f109570d"
+  integrity sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==
+
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
+    serialize-javascript "^4.0.0"
+    terser "^5.0.0"
+
+rollup-plugin-typescript2@^0.31.2:
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.2.tgz#463aa713a7e2bf85b92860094b9f7fb274c5a4d8"
+  integrity sha512-hRwEYR1C8xDGVVMFJQdEVnNAeWRvpaY97g5mp3IeLnzhNXzSVq78Ye/BJ9PAaUfN4DXa/uDnqerifMOaMFY54Q==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.2"
+    "@yarn-tool/resolve-package" "^1.0.40"
+    find-cache-dir "^3.3.2"
+    fs-extra "^10.0.0"
+    resolve "^1.20.0"
+    tslib "^2.3.1"
+
+rollup@^2.70.1:
+  version "2.70.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
+  integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+safe-buffer@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -2154,6 +2464,13 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -2181,7 +2498,7 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-support@^0.5.6:
+source-map-support@^0.5.6, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -2199,10 +2516,15 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2279,6 +2601,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -2291,6 +2618,16 @@ terminal-link@^2.0.0:
   dependencies:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
+
+terser@^5.0.0:
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
+  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
+  dependencies:
+    acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.20"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -2353,6 +2690,11 @@ ts-jest@^27.1.1:
     semver "7.x"
     yargs-parser "20.x"
 
+tslib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -2386,6 +2728,20 @@ universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+upath2@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/upath2/-/upath2-3.1.12.tgz#441b3dfbadde21731017bd1b7beb169498efd0a9"
+  integrity sha512-yC3eZeCyCXFWjy7Nu4pgjLhXNYjuzuUmJiRgSSw6TJp8Emc+E4951HGPJf+bldFC5SL7oBLeNbtm1fGzXn2gxw==
+  dependencies:
+    path-is-network-drive "^1.0.13"
+    path-strip-sep "^1.0.10"
+    tslib "^2.3.1"
 
 v8-to-istanbul@^8.1.0:
   version "8.1.0"
@@ -2526,3 +2882,8 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
- [x] Support query-parameters by accepting a `$query` property in the `Replacer` object. The `$` sign is prefixed to avoid collision with a `query` key in the link itself

Thanks to [@nmalancea](https://github.com/nmalancea) for the suggestion raised in [this](https://github.com/Lindeneg/cl-fill-link/issues/5) issue.

- [x] Support more primitive value types instead of just `string`. If a non-string type is received, it's simply converted, then consumer don't have to do it.

- [x] Test new query support with Jest

- [x] (Probably) setup rollup to build and minify. Due to the smallness of this program I had not done it yet, but might as well in this PR.